### PR TITLE
fix: FASTQ read ID was not splitting on tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minimap2-sys"
-version = "0.1.19+minimap2.2.28"
+version = "0.1.20+minimap2.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b27cbfa7368abd87de720ae844d9aad28452fa5b415d8df629497b23c030ad6"
+checksum = "47d31565115502ac93fd101537bc1d6e32e56dd51538c42c82b927a3d58dad42"
 dependencies = [
  "cc",
  "libz-sys",

--- a/liblrge/Cargo.toml
+++ b/liblrge/Cargo.toml
@@ -18,7 +18,7 @@ log.workspace = true
 needletail = { version = "0.6.0", default-features = false }
 rand = "0.8.5"
 
-minimap2-sys = "0.1.19"
+minimap2-sys = "0.1.20"
 libc = "0.2.164"
 crossbeam-channel = "0.5.13"
 rayon = "1.10.0"


### PR DESCRIPTION
This meant the whole FASTQ header was being used as the query name.

Some other small changes lioke bumping the minimap2-sys library version to incorporate the double free fix and using `CString` instead of casting byte slices to C char arrays blah blah as this ensures the query name is null-terminated, which is a requirement for minimap2