### PR TITLE
Updates for minimap2 indexing, internal matches removal and memory usage optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ Options:
           
           [default: 0.3]
 
+      --use-min-ref
+          Use the smaller Q/T dataset as minimap2 reference (for two-set strategy)
+
   -q, --quiet...
           `-q` only show errors and warnings. `-qq` only show errors. `-qqq` shows nothing
 

--- a/README.md
+++ b/README.md
@@ -339,15 +339,10 @@ Options:
           
           [default: 0.65]
 
-      --max-overhang-size <INT>
-          Maximum overhang size for internal overlap filtering
-          
-          [default: 1000]
-
       --max-overhang-ratio <FLOAT>
-          Maximum overhang ratio for internal overlap filtering
+          Maximum overhang size to alignment length ratio for internal overlap filtering
           
-          [default: 0.8]
+          [default: 0.3]
 
   -q, --quiet...
           `-q` only show errors and warnings. `-qq` only show errors. `-qqq` shows nothing

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Options:
   -Q, --query <INT>          Query number of reads to use (for two-set strategy; default) [default: 5000]
   -n, --num <INT>            Number of reads to use (for all-vs-all strategy)
   -P, --platform <PLATFORM>  Sequencing platform of the reads [default: ont] [possible values: ont, pb]
+  -F, --do-filter            Exclude overlaps for internal matches
   -t, --threads <INT>        Number of threads to use [default: 1]
   -C, --keep-temp            Don't clean up temporary files
   -D, --temp <DIR>           Temporary directory for storing intermediate files
@@ -283,16 +284,17 @@ Arguments:
 Options:
   -o, --output <OUTPUT>
           Output file for the estimate
-
+          
           [default: -]
 
   -T, --target <INT>
           Target number of reads to use (for two-set strategy; default)
-
+          
           [default: 10000]
+
   -Q, --query <INT>
           Query number of reads to use (for two-set strategy; default)
-
+          
           [default: 5000]
 
   -n, --num <INT>
@@ -300,13 +302,16 @@ Options:
 
   -P, --platform <PLATFORM>
           Sequencing platform of the reads
-
+          
           [default: ont]
           [possible values: ont, pb]
 
+  -F, --do-filter
+          Exclude overlaps for internal matches
+
   -t, --threads <INT>
           Number of threads to use
-
+          
           [default: 1]
 
   -C, --keep-temp
@@ -326,13 +331,23 @@ Options:
 
       --q1 <FLOAT>
           The lower quantile to use for the estimate
-
+          
           [default: 0.15]
 
       --q3 <FLOAT>
           The upper quantile to use for the estimate
-
+          
           [default: 0.65]
+
+      --max-overhang-size <INT>
+          Maximum overhang size for internal overlap filtering
+          
+          [default: 1000]
+
+      --max-overhang-ratio <FLOAT>
+          Maximum overhang ratio for internal overlap filtering
+          
+          [default: 0.8]
 
   -q, --quiet...
           `-q` only show errors and warnings. `-qq` only show errors. `-qqq` shows nothing

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Options:
       --max-overhang-ratio <FLOAT>
           Maximum overhang size to alignment length ratio for internal overlap filtering
           
-          [default: 0.3]
+          [default: 0.2]
 
       --use-min-ref
           Use the smaller Q/T dataset as minimap2 reference (for two-set strategy)

--- a/liblrge/src/ava.rs
+++ b/liblrge/src/ava.rs
@@ -72,6 +72,8 @@ pub struct AvaStrategy {
     input: PathBuf,
     /// The number of reads to use in the strategy.
     num_reads: usize,
+    /// The number of bases to use in the strategy.
+    num_bases: usize,
     /// The directory to which all intermediate files will be written.
     tmpdir: PathBuf,
     /// Number of threads to use with minimap2.
@@ -156,6 +158,8 @@ impl AvaStrategy {
 
             idx += 1;
         }
+
+        self.num_bases = sum_len;
 
         debug!("Reads written to: {}", out_file.display());
         debug!("Total bases written: {}", sum_len);

--- a/liblrge/src/ava.rs
+++ b/liblrge/src/ava.rs
@@ -77,8 +77,6 @@ pub struct AvaStrategy {
     num_bases: usize,
     /// Remove overlaps for internal matches.
     remove_internal: bool,
-    /// Maximum overhang size
-    max_overhang_size: i32,
     /// Maximum overhang ratio
     max_overhang_ratio: f32,
     /// The directory to which all intermediate files will be written.
@@ -306,7 +304,7 @@ impl AvaStrategy {
                                             cmp::min(mapping.query_len - mapping.query_end, mapping.target_start);
                                     }
                                     maplen = cmp::max(mapping.query_end - mapping.query_start, mapping.target_end - mapping.target_start);
-                                    if overhang > self.max_overhang_size || overhang > ((maplen as f32) * self.max_overhang_ratio) as i32 {
+                                    if overhang > ((maplen as f32) * self.max_overhang_ratio) as i32 {
                                         continue;
                                     }
                                 }

--- a/liblrge/src/ava/builder.rs
+++ b/liblrge/src/ava/builder.rs
@@ -8,7 +8,6 @@ pub struct Builder {
     num_reads: usize,
     num_bases: usize,
     remove_internal: bool,
-    max_overhang_size: i32,
     max_overhang_ratio: f32,
     tmpdir: PathBuf,
     threads: usize,
@@ -23,8 +22,7 @@ impl Default for Builder {
             num_reads: DEFAULT_AVA_NUM_READS,
             num_bases: 0,
             remove_internal: false,
-            max_overhang_size: 1000,
-            max_overhang_ratio: 0.8,
+            max_overhang_ratio: 0.3,
             tmpdir,
             threads: 1,
             seed: None,
@@ -62,10 +60,9 @@ impl Builder {
     }
 
     /// Set option for removing the overlaps representing internal matches
-    pub fn remove_internal(mut self, do_filt: bool, size: i32, ratio: f32) -> Self {
+    pub fn remove_internal(mut self, do_filt: bool, ratio: f32) -> Self {
         self.remove_internal = do_filt;
         if do_filt {
-            self.max_overhang_size = size;
             self.max_overhang_ratio = ratio;
         }
         self
@@ -146,7 +143,6 @@ impl Builder {
             num_reads: self.num_reads,
             num_bases: self.num_bases,
             remove_internal: self.remove_internal,
-            max_overhang_size: self.max_overhang_size,
             max_overhang_ratio: self.max_overhang_ratio,
             tmpdir: self.tmpdir,
             threads: self.threads,

--- a/liblrge/src/ava/builder.rs
+++ b/liblrge/src/ava/builder.rs
@@ -7,6 +7,9 @@ use crate::Platform;
 pub struct Builder {
     num_reads: usize,
     num_bases: usize,
+    remove_internal: bool,
+    max_overhang_size: i32,
+    max_overhang_ratio: f32,
     tmpdir: PathBuf,
     threads: usize,
     seed: Option<u64>,
@@ -19,6 +22,9 @@ impl Default for Builder {
         Self {
             num_reads: DEFAULT_AVA_NUM_READS,
             num_bases: 0,
+            remove_internal: false,
+            max_overhang_size: 1000,
+            max_overhang_ratio: 0.8,
             tmpdir,
             threads: 1,
             seed: None,
@@ -52,6 +58,16 @@ impl Builder {
     /// ```
     pub fn num_reads(mut self, num_reads: usize) -> Self {
         self.num_reads = num_reads;
+        self
+    }
+
+    /// Set option for removing the overlaps representing internal matches
+    pub fn remove_internal(mut self, do_filt: bool, size: i32, ratio: f32) -> Self {
+        self.remove_internal = do_filt;
+        if do_filt {
+            self.max_overhang_size = size;
+            self.max_overhang_ratio = ratio;
+        }
         self
     }
 
@@ -129,6 +145,9 @@ impl Builder {
             input: input.as_ref().to_path_buf(),
             num_reads: self.num_reads,
             num_bases: self.num_bases,
+            remove_internal: self.remove_internal,
+            max_overhang_size: self.max_overhang_size,
+            max_overhang_ratio: self.max_overhang_ratio,
             tmpdir: self.tmpdir,
             threads: self.threads,
             seed: self.seed,

--- a/liblrge/src/ava/builder.rs
+++ b/liblrge/src/ava/builder.rs
@@ -6,6 +6,7 @@ use crate::Platform;
 /// A builder for [`AvaStrategy`].
 pub struct Builder {
     num_reads: usize,
+    num_bases: usize,
     tmpdir: PathBuf,
     threads: usize,
     seed: Option<u64>,
@@ -17,6 +18,7 @@ impl Default for Builder {
         let tmpdir = std::env::temp_dir();
         Self {
             num_reads: DEFAULT_AVA_NUM_READS,
+            num_bases: 0,
             tmpdir,
             threads: 1,
             seed: None,
@@ -126,6 +128,7 @@ impl Builder {
         AvaStrategy {
             input: input.as_ref().to_path_buf(),
             num_reads: self.num_reads,
+            num_bases: self.num_bases,
             tmpdir: self.tmpdir,
             threads: self.threads,
             seed: self.seed,

--- a/liblrge/src/ava/builder.rs
+++ b/liblrge/src/ava/builder.rs
@@ -22,7 +22,7 @@ impl Default for Builder {
             num_reads: DEFAULT_AVA_NUM_READS,
             num_bases: 0,
             remove_internal: false,
-            max_overhang_ratio: 0.3,
+            max_overhang_ratio: 0.2,
             tmpdir,
             threads: 1,
             seed: None,

--- a/liblrge/src/estimate.rs
+++ b/liblrge/src/estimate.rs
@@ -152,7 +152,7 @@ pub(crate) fn per_read_estimate(
 
     let ovlap_ratio: f32 = n_target_reads as f32 / n_ovlaps as f32;
 
-    ovlap_ratio * (read_len as f32 + avg_target_len - 2.0 * ovlap_thresh as f32)
+    read_len as f32 + ovlap_ratio * (read_len as f32 + avg_target_len - 2.0 * ovlap_thresh as f32 + 1.0)
 }
 
 #[cfg(test)]

--- a/liblrge/src/minimap2/aligner.rs
+++ b/liblrge/src/minimap2/aligner.rs
@@ -108,6 +108,19 @@ impl Aligner {
         self
     }
 
+    /// Set index batch_size '-I'
+    pub fn with_index_size(mut self, batch: usize) -> Self {
+        if batch > 0 {
+            self.idxopt.batch_size = batch as u64;    
+        } else {
+            // set -I32G
+            // self.idxopt.batch_size = 0x800000000;
+            // set to maximum to avoid multi-part indexing
+            self.idxopt.batch_size = 0x7fffffffffffffff;
+        }
+        self
+    }
+
     /// Set index parameters for minimap2 using builder pattern
     /// Creates the index as well with the given number of threads (set at struct creation).
     /// You must set the number of threads before calling this function.
@@ -159,7 +172,7 @@ impl Aligner {
             mm_idx_reader_open(path_str.as_ptr(), &self.idxopt, output.as_ptr())
         });
 
-        let idx;
+        let idx: MaybeUninit<*mut mm_idx_t>;
 
         let idx_reader = unsafe { idx_reader.assume_init() };
 
@@ -305,6 +318,7 @@ impl AlignerWrapper {
             .preset(preset.as_bytes())
             .dual(dual)
             .with_index_threads(threads)
+            .with_index_size(0)
             .with_index(target_file, None)
             .unwrap();
 

--- a/liblrge/src/twoset.rs
+++ b/liblrge/src/twoset.rs
@@ -84,8 +84,6 @@ pub struct TwoSetStrategy {
     query_num_bases: usize,
     /// Remove overlaps for internal matches.
     remove_internal: bool,
-    /// Maximum overhang size
-    max_overhang_size: i32,
     /// Maximum overhang ratio
     max_overhang_ratio: f32,
     /// The directory to which all intermediate files will be written.
@@ -314,7 +312,7 @@ impl TwoSetStrategy {
                                             cmp::min(mapping.query_len - mapping.query_end, mapping.target_start);
                                     }
                                     maplen = cmp::max(mapping.query_end - mapping.query_start, mapping.target_end - mapping.target_start);
-                                    if overhang > self.max_overhang_size || overhang > ((maplen as f32) * self.max_overhang_ratio) as i32 {
+                                    if overhang > ((maplen as f32) * self.max_overhang_ratio) as i32 {
                                         continue;
                                     }
                                 }
@@ -519,7 +517,7 @@ impl TwoSetStrategy {
                                             cmp::min(mapping.query_len - mapping.query_end, mapping.target_start);
                                     }
                                     maplen = cmp::max(mapping.query_end - mapping.query_start, mapping.target_end - mapping.target_start);
-                                    if overhang > self.max_overhang_size || overhang > ((maplen as f32) * self.max_overhang_ratio) as i32 {
+                                    if overhang > ((maplen as f32) * self.max_overhang_ratio) as i32 {
                                         continue;
                                     }
                                 }

--- a/liblrge/src/twoset.rs
+++ b/liblrge/src/twoset.rs
@@ -86,6 +86,8 @@ pub struct TwoSetStrategy {
     remove_internal: bool,
     /// Maximum overhang ratio
     max_overhang_ratio: f32,
+    /// Use the smaller Q/T dataset as minimap2 reference
+    use_min_ref: bool,
     /// The directory to which all intermediate files will be written.
     tmpdir: PathBuf,
     /// Number of threads to use with minimap2.
@@ -596,14 +598,14 @@ impl Estimate for TwoSetStrategy {
             Platform::Nanopore => Preset::AvaOnt,
         };
 
-        if self.target_num_bases < self.query_num_bases {
-            // align query to target
-            let aligner = AlignerWrapper::new(&target_file, self.threads, preset, true)?;
-            self.align_reads(aligner, query_file, avg_target_len)
-        } else {
+        if self.use_min_ref && self.target_num_bases > self.query_num_bases {
             // align target to query
             let aligner = AlignerWrapper::new(&query_file, self.threads, preset, true)?;
             self.align_reads_inverse(aligner, target_file, avg_target_len)
+        } else {
+            // align query to target
+            let aligner = AlignerWrapper::new(&target_file, self.threads, preset, true)?;
+            self.align_reads(aligner, query_file, avg_target_len)
         }
     }
 }

--- a/liblrge/src/twoset/builder.rs
+++ b/liblrge/src/twoset/builder.rs
@@ -28,7 +28,7 @@ impl Default for Builder {
             query_num_reads: DEFAULT_QUERY_NUM_READS,
             query_num_bases: 0,
             remove_internal: false,
-            max_overhang_ratio: 0.3,
+            max_overhang_ratio: 0.2,
             use_min_ref: false,
             tmpdir,
             threads: 1,

--- a/liblrge/src/twoset/builder.rs
+++ b/liblrge/src/twoset/builder.rs
@@ -7,7 +7,9 @@ use super::{TwoSetStrategy, DEFAULT_QUERY_NUM_READS, DEFAULT_TARGET_NUM_READS};
 /// A builder for [`TwoSetStrategy`].
 pub struct Builder {
     target_num_reads: usize,
+    target_num_bases: usize,
     query_num_reads: usize,
+    query_num_bases: usize,
     tmpdir: PathBuf,
     threads: usize,
     seed: Option<u64>,
@@ -19,7 +21,9 @@ impl Default for Builder {
         let tmpdir = std::env::temp_dir();
         Self {
             target_num_reads: DEFAULT_TARGET_NUM_READS,
+            target_num_bases: 0,
             query_num_reads: DEFAULT_QUERY_NUM_READS,
+            query_num_bases: 0,
             tmpdir,
             threads: 1,
             seed: None,
@@ -145,7 +149,9 @@ impl Builder {
         TwoSetStrategy {
             input: input.as_ref().to_path_buf(),
             target_num_reads: self.target_num_reads,
+            target_num_bases: self.target_num_bases,
             query_num_reads: self.query_num_reads,
+            query_num_bases: self.query_num_bases,
             tmpdir: self.tmpdir,
             threads: self.threads,
             seed: self.seed,

--- a/liblrge/src/twoset/builder.rs
+++ b/liblrge/src/twoset/builder.rs
@@ -10,6 +10,9 @@ pub struct Builder {
     target_num_bases: usize,
     query_num_reads: usize,
     query_num_bases: usize,
+    remove_internal: bool,
+    max_overhang_size: i32,
+    max_overhang_ratio: f32,
     tmpdir: PathBuf,
     threads: usize,
     seed: Option<u64>,
@@ -24,6 +27,9 @@ impl Default for Builder {
             target_num_bases: 0,
             query_num_reads: DEFAULT_QUERY_NUM_READS,
             query_num_bases: 0,
+            remove_internal: false,
+            max_overhang_size: 1000,
+            max_overhang_ratio: 0.8,
             tmpdir,
             threads: 1,
             seed: None,
@@ -77,6 +83,16 @@ impl Builder {
     /// ```
     pub fn query_num_reads(mut self, query_num_reads: usize) -> Self {
         self.query_num_reads = query_num_reads;
+        self
+    }
+
+    /// Set option for removing the overlaps representing internal matches
+    pub fn remove_internal(mut self, do_filt: bool, size: i32, ratio: f32) -> Self {
+        self.remove_internal = do_filt;
+        if do_filt {
+            self.max_overhang_size = size;
+            self.max_overhang_ratio = ratio;
+        }
         self
     }
 
@@ -152,6 +168,9 @@ impl Builder {
             target_num_bases: self.target_num_bases,
             query_num_reads: self.query_num_reads,
             query_num_bases: self.query_num_bases,
+            remove_internal: self.remove_internal,
+            max_overhang_size: self.max_overhang_size,
+            max_overhang_ratio: self.max_overhang_ratio,
             tmpdir: self.tmpdir,
             threads: self.threads,
             seed: self.seed,

--- a/liblrge/src/twoset/builder.rs
+++ b/liblrge/src/twoset/builder.rs
@@ -12,6 +12,7 @@ pub struct Builder {
     query_num_bases: usize,
     remove_internal: bool,
     max_overhang_ratio: f32,
+    use_min_ref: bool,
     tmpdir: PathBuf,
     threads: usize,
     seed: Option<u64>,
@@ -28,6 +29,7 @@ impl Default for Builder {
             query_num_bases: 0,
             remove_internal: false,
             max_overhang_ratio: 0.3,
+            use_min_ref: false,
             tmpdir,
             threads: 1,
             seed: None,
@@ -90,6 +92,12 @@ impl Builder {
         if do_filt {
             self.max_overhang_ratio = ratio;
         }
+        self
+    }
+
+    /// Set option for using the smaller Q/T dataset as minimap2 reference
+    pub fn use_min_ref(mut self, use_min_ref: bool) -> Self {
+        self.use_min_ref = use_min_ref;
         self
     }
 
@@ -167,6 +175,7 @@ impl Builder {
             query_num_bases: self.query_num_bases,
             remove_internal: self.remove_internal,
             max_overhang_ratio: self.max_overhang_ratio,
+            use_min_ref: self.use_min_ref,
             tmpdir: self.tmpdir,
             threads: self.threads,
             seed: self.seed,

--- a/liblrge/src/twoset/builder.rs
+++ b/liblrge/src/twoset/builder.rs
@@ -11,7 +11,6 @@ pub struct Builder {
     query_num_reads: usize,
     query_num_bases: usize,
     remove_internal: bool,
-    max_overhang_size: i32,
     max_overhang_ratio: f32,
     tmpdir: PathBuf,
     threads: usize,
@@ -28,8 +27,7 @@ impl Default for Builder {
             query_num_reads: DEFAULT_QUERY_NUM_READS,
             query_num_bases: 0,
             remove_internal: false,
-            max_overhang_size: 1000,
-            max_overhang_ratio: 0.8,
+            max_overhang_ratio: 0.3,
             tmpdir,
             threads: 1,
             seed: None,
@@ -87,10 +85,9 @@ impl Builder {
     }
 
     /// Set option for removing the overlaps representing internal matches
-    pub fn remove_internal(mut self, do_filt: bool, size: i32, ratio: f32) -> Self {
+    pub fn remove_internal(mut self, do_filt: bool, ratio: f32) -> Self {
         self.remove_internal = do_filt;
         if do_filt {
-            self.max_overhang_size = size;
             self.max_overhang_ratio = ratio;
         }
         self
@@ -169,7 +166,6 @@ impl Builder {
             query_num_reads: self.query_num_reads,
             query_num_bases: self.query_num_bases,
             remove_internal: self.remove_internal,
-            max_overhang_size: self.max_overhang_size,
             max_overhang_ratio: self.max_overhang_ratio,
             tmpdir: self.tmpdir,
             threads: self.threads,

--- a/lrge/src/cli.rs
+++ b/lrge/src/cli.rs
@@ -4,8 +4,7 @@ use std::path::PathBuf;
 
 const TARGET_NUM_READS: &str = "10000";
 const QUERY_NUM_READS: &str = "5000";
-const MAX_OVERHANG_SIZE: &str = "1000";
-const MAX_OVERHANG_RATIO: &str = "0.8";
+const MAX_OVERHANG_RATIO: &str = "0.3";
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -70,10 +69,6 @@ pub struct Args {
     #[arg(long = "q3", value_name = "FLOAT", default_value_t = liblrge::estimate::UPPER_QUANTILE, value_parser = validate_high_quantile, hide_short_help = true)]
     pub upper_q: f32,
 
-    /// Maximum overhang size for internal overlap filtering
-    #[arg(long = "max-overhang-size", value_name = "INT", default_value = MAX_OVERHANG_SIZE, value_parser = validate_overhang_size, hide_short_help = true)]
-    pub max_overhang_size: i32,
-
     /// Maximum overhang ratio for internal overlap filtering
     #[arg(long = "max-overhang-ratio", value_name = "FLOAT", default_value = MAX_OVERHANG_RATIO, value_parser = validate_overhang_ratio, hide_short_help = true)]
     pub max_overhang_ratio: f32,
@@ -120,21 +115,6 @@ fn validate_low_quantile(s: &str) -> Result<f32, String> {
 /// A value parser for the upper quantile
 fn validate_high_quantile(s: &str) -> Result<f32, String> {
     validate_quantile(s, 0.5, 1.0)
-}
-
-/// A value parser for the maximum overhang size
-fn validate_overhang_size(s: &str) -> Result<i32, String> {
-    let value: i32 = s
-        .parse()
-        .map_err(|_| format!("`{}` is not a valid number", s))?;
-    if value >= 0 {
-        Ok(value)
-    } else {
-        Err(format!(
-            "Value `{}` must be a non-negative integer",
-            s
-        ))
-    }
 }
 
 /// A value parser for the maximum overhang ratio

--- a/lrge/src/cli.rs
+++ b/lrge/src/cli.rs
@@ -69,7 +69,7 @@ pub struct Args {
     #[arg(long = "q3", value_name = "FLOAT", default_value_t = liblrge::estimate::UPPER_QUANTILE, value_parser = validate_high_quantile, hide_short_help = true)]
     pub upper_q: f32,
 
-    /// Maximum overhang ratio for internal overlap filtering
+    /// Maximum overhang size to alignment length ratio for internal overlap filtering
     #[arg(long = "max-overhang-ratio", value_name = "FLOAT", default_value = MAX_OVERHANG_RATIO, value_parser = validate_overhang_ratio, hide_short_help = true)]
     pub max_overhang_ratio: f32,
 

--- a/lrge/src/cli.rs
+++ b/lrge/src/cli.rs
@@ -73,6 +73,10 @@ pub struct Args {
     #[arg(long = "max-overhang-ratio", value_name = "FLOAT", default_value = MAX_OVERHANG_RATIO, value_parser = validate_overhang_ratio, hide_short_help = true)]
     pub max_overhang_ratio: f32,
 
+    /// Use the smaller Q/T dataset as minimap2 reference (for two-set strategy)
+    #[arg(long = "use-min-ref", hide_short_help = true)]
+    pub use_min_ref: bool,
+
     /// `-q` only show errors and warnings. `-qq` only show errors. `-qqq` shows nothing.
     #[arg(short, long, action = clap::ArgAction::Count, conflicts_with = "verbose")]
     pub quiet: u8,

--- a/lrge/src/cli.rs
+++ b/lrge/src/cli.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 const TARGET_NUM_READS: &str = "10000";
 const QUERY_NUM_READS: &str = "5000";
-const MAX_OVERHANG_RATIO: &str = "0.3";
+const MAX_OVERHANG_RATIO: &str = "0.2";
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/lrge/src/main.rs
+++ b/lrge/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
         info!("Running all-vs-all strategy with {} reads", num);
         let builder = liblrge::ava::Builder::new()
             .num_reads(num)
-            .remove_internal(args.do_filt, args.max_overhang_size, args.max_overhang_ratio)
+            .remove_internal(args.do_filt, args.max_overhang_ratio)
             .threads(args.threads)
             .tmpdir(tmpdir.path())
             .seed(args.seed);
@@ -73,7 +73,7 @@ fn main() -> Result<()> {
         let builder = liblrge::twoset::Builder::new()
             .target_num_reads(target_num_reads)
             .query_num_reads(query_num_reads)
-            .remove_internal(args.do_filt, args.max_overhang_size, args.max_overhang_ratio)
+            .remove_internal(args.do_filt, args.max_overhang_ratio)
             .threads(args.threads)
             .tmpdir(tmpdir.path())
             .seed(args.seed);

--- a/lrge/src/main.rs
+++ b/lrge/src/main.rs
@@ -57,6 +57,7 @@ fn main() -> Result<()> {
         info!("Running all-vs-all strategy with {} reads", num);
         let builder = liblrge::ava::Builder::new()
             .num_reads(num)
+            .remove_internal(args.do_filt, args.max_overhang_size, args.max_overhang_ratio)
             .threads(args.threads)
             .tmpdir(tmpdir.path())
             .seed(args.seed);
@@ -72,6 +73,7 @@ fn main() -> Result<()> {
         let builder = liblrge::twoset::Builder::new()
             .target_num_reads(target_num_reads)
             .query_num_reads(query_num_reads)
+            .remove_internal(args.do_filt, args.max_overhang_size, args.max_overhang_ratio)
             .threads(args.threads)
             .tmpdir(tmpdir.path())
             .seed(args.seed);

--- a/lrge/src/main.rs
+++ b/lrge/src/main.rs
@@ -74,6 +74,7 @@ fn main() -> Result<()> {
             .target_num_reads(target_num_reads)
             .query_num_reads(query_num_reads)
             .remove_internal(args.do_filt, args.max_overhang_ratio)
+            .use_min_ref(args.use_min_ref)
             .threads(args.threads)
             .tmpdir(tmpdir.path())
             .seed(args.seed);


### PR DESCRIPTION
There are three major updates:

1. disabled multi-part indexing for minimap2
2. added options to remove internal matches
3. optimised memory usage by using the smaller dataset as minimap2 reference instead of always using 'target'